### PR TITLE
fix: Use a published flag to filter related posts

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -38,7 +38,9 @@ export default async function PostPage({
 
   const relatedPosts: Post[] = allPosts.filter(
     (p) =>
-      p.slug !== slug && p.categories.some((v) => post.categories.includes(v))
+      p.slug !== slug &&
+      p.published &&
+      p.categories.some((v) => post.categories.includes(v))
   );
 
   const recordMap = await getRecordMap(post.id);


### PR DESCRIPTION
fix: https://github.com/wildcatco/notion-blog/issues/4

when we try to open a post with a published flag is false on a related posts section, it goes to a 404 page. so, no problem
however it would be better to display only published posts in that place